### PR TITLE
LINENotifyによる通知機能の追加

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -31,5 +31,6 @@ jobs:
           poetry run python src/carrier-owl.py
         env:
           SLACK_ID: ${{ secrets.SLACK_ID }}
+          LINE_TOKEN: ${{ secrets.LINE_TOKEN }}
 
 

--- a/src/carrier-owl.py
+++ b/src/carrier-owl.py
@@ -20,7 +20,7 @@ warnings.filterwarnings('ignore')
 
 def get_articles_info(subject):
     weekday_dict = {0: 'Mon', 1: 'Tue', 2: 'Wed', 3: 'Thu',
-                  4: 'Fri', 5: 'Sat', 6: 'Sun'}
+                    4: 'Fri', 5: 'Sat', 6: 'Sun'}
     url = f'https://arxiv.org/list/{subject}/pastweek?show=100000'
     response = requests.get(url)
     html = response.text
@@ -63,8 +63,8 @@ def serch_keywords(id_list, keywords_dict):
         bs = BeautifulSoup(html)
         title = bs.find('meta', attrs={'property': 'og:title'})['content']
         abstract = bs.find(
-                'meta',
-                attrs={'property': 'og:description'})['content']
+            'meta',
+            attrs={'property': 'og:description'})['content']
 
         sum_score = 0
         hit_kwd_list = []
@@ -121,6 +121,44 @@ def send2slack(results, slack):
         slack.notify(text=text_slack)
 
 
+def send2line(results, line_notify_token):
+    line_notify_api = 'https://notify-api.line.me/api/notify'
+    headers = {'Authorization': f'Bearer {line_notify_token}'}
+
+    urls = results[0]
+    titles = results[1]
+    abstracts = results[2]
+    words = results[3]
+    scores = results[4]
+
+    # rank
+    idxs_sort = np.argsort(scores)
+    idxs_sort = idxs_sort[::-1]
+
+    # 通知
+    star = '*'*120
+
+    for i in idxs_sort:
+        url = urls[i]
+        title = titles[i]
+        abstract = abstracts[i]
+        word = words[i]
+        score = scores[i]
+
+        text_line = f'''
+        \n score: `{score}`
+        \n hit keywords: `{word}`
+        \n url: {url}
+        \n title:    {title}
+        \n abstract: 
+        \n \t {abstract}
+        \n {star}
+        '''
+
+        data = {'message': f'message: {text_line}'}
+        requests.post(line_notify_api, headers=headers, data=data)
+
+
 def get_translated_text(from_lang, to_lang, from_text):
     '''
     https://qiita.com/fujino-fpu/items/e94d4ff9e7a5784b2987
@@ -132,7 +170,8 @@ def get_translated_text(from_lang, to_lang, from_text):
     from_text = urllib.parse.quote(from_text)
 
     # url作成
-    url = 'https://www.deepl.com/translator#' + from_lang + '/' + to_lang + '/' + from_text
+    url = 'https://www.deepl.com/translator#' + \
+        from_lang + '/' + to_lang + '/' + from_text
 
     # ヘッドレスモードでブラウザを起動
     options = Options()
@@ -182,6 +221,10 @@ def main():
     id_list = get_articles_info(config['subject'])
     results = serch_keywords(id_list, config['keywords'])
     send2slack(results, slack)
+
+    # ============LINE Notify===================
+    line_notify_token = os.getenv("LINE_TOKEN")
+    send2line(results, line_notify_token)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summay
- LINENotifyによる通知の追加
- cron.ymlの環境変数にLINE_TOKENを追加
- 折り返し等の軽微な修正

### Requirements
Github→settings→secretsで行ったSLACK_IDの登録と同様に、`LINE_TOKNE`という名前でLINE Notifyのアクセストークンの登録をお願いします。GitHub Actions の workflow/cron.ymlで、secrets.LINE_ID という名前で参照しています。

#### LINE通知導入手順
1. LINE Notify(https://notify-bot.line.me/ja/) にアクセスし、ログイン
2. ページ右上にある自分の名前をクリックし、マイページに移動
3. マイページ下部でアクセストークン発行
    - 下記ページで発行
    <img width="1360" alt="スクリーンショット 2020-12-30 14 23 36" src="https://user-images.githubusercontent.com/59816595/103331820-f594d680-4aaa-11eb-86a6-ce18f9f7515c.png">
 
    - 発行時、通知するトークルームを設定できるので同じトークルームに入っている複数名に通知可能
4. Github Secretsにアクセストークンを追加
    - 先程発行したアクセストークンを`LINE_TOKEN`で追加 

### 表示例
![line_notify](https://user-images.githubusercontent.com/59816595/103332016-d185c500-4aab-11eb-853b-553a7ee0b04e.jpg)
