### PR TITLE
[test] bs.find(meta)が None になったときの処理を追加

### DIFF
--- a/src/carrier-owl.py
+++ b/src/carrier-owl.py
@@ -61,6 +61,11 @@ def serch_keywords(id_list, keywords_dict):
         html = response.text
 
         bs = BeautifulSoup(html)
+        
+        # metaデータが見つからないときはスキップ
+        if bs.find('meta') is None :
+            continue
+
         title = bs.find('meta', attrs={'property': 'og:title'})['content']
         abstract = bs.find(
                 'meta',


### PR DESCRIPTION
issue #43  に関しての処理です。
私の環境では、bs.find() の結果が None になった場合はスキップすることで、workflow 自体は最後まで通りました。
ご参考になれば幸いです。