### PR TITLE
[Fix] use 0 for Sunday in cron syntax

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -3,7 +3,7 @@ name: Carrier Owl
 on:
   schedule:
     # github actions のデフォルトの time zone が UTC なので、日本時間 - 9時間 した値を書く
-    - cron:  '50 0 * * 3,4,5,6,7'
+    - cron:  '50 0 * * 0,3,4,5,6'
   workflow_dispatch:
   
   push:


### PR DESCRIPTION
### はじめに
素敵なツールの作成、ありがとうございます！

### 概要
cronで日曜日を指定するには、0を使用するようです。

現状7が指定されており、GitHub Actionsがcron記述を認識できず、[実行に失敗](https://github.com/fkubota/Carrier-Owl/actions/runs/894933182)しておりました。

軽微な修正ですが、7の代わりに0を使用するようにしました。