### PR TITLE
Draft: Add message template

### DIFF
--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -1,4 +1,3 @@
-from re import template
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -77,7 +76,7 @@ def send2app(text: str, slack_id: str, line_token: str) -> None:
         requests.post(line_notify_api, headers=headers, data=data)
 
 
-def notify(results: list, template: str, slack_id: str, line_token: str) -> None:
+def notify(results: list, slack_id: str, line_token: str) -> None:
     # 通知
     star = '*'*80
     today = datetime.date.today()
@@ -167,15 +166,6 @@ def main():
     subject = config['subject']
     keywords = config['keywords']
     score_threshold = float(config['score_threshold'])
-    template = config['template']
-    if template is None:
-        template = '\n score: `${score}`'\
-                   '\n hit keywords: `${words}`'\
-                   '\n url: ${url}'\
-                   '\n title:    ${title}'\
-                   '\n abstract:'\
-                   '\n \t ${abstract_trans}'\
-                   '\n ${star}'
 
     day_before_yesterday = datetime.datetime.today() - datetime.timedelta(days=2)
     day_before_yesterday_str = day_before_yesterday.strftime('%Y%m%d')
@@ -191,7 +181,7 @@ def main():
 
     slack_id = os.getenv("SLACK_ID") or args.slack_id
     line_token = os.getenv("LINE_TOKEN") or args.line_token
-    notify(results, template, slack_id, line_token)
+    notify(results, slack_id, line_token)
 
 
 if __name__ == "__main__":

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -70,6 +70,8 @@ def nice_str(obj) -> str:
     if isinstance(obj, list):
         if all(type(elem) is str for elem in obj):
             return ', '.join(obj)
+    if type(obj) is str:
+        return obj.replace('\n', ' ')
     return str(obj)
 
 def notify(results: list, template: str, slack_id: str, line_token: str) -> None:
@@ -84,15 +86,15 @@ def notify(results: list, template: str, slack_id: str, line_token: str) -> None
         article = result.article
         words = nice_str(result.words)
         score = result.score
+        article_str = {key: nice_str(article[key]) for key in article.keys()}
 
-        title_trans = get_translated_text('ja', 'en', article['title'].replace('\n', ' '))
-        summary_trans = get_translated_text('ja', 'en', article['summary'].replace('\n', ' '))
+        title_trans = get_translated_text('ja', 'en', article_str['title'])
+        summary_trans = get_translated_text('ja', 'en', article_str['summary'])
         # summary_trans = textwrap.wrap(summary_trans, 40)  # 40行で改行
         # summary_trans = '\n'.join(summary_trans)
-        result_str = {key: nice_str(article[key]) for key in article.keys()}
 
         text = Template(template).substitute(
-            result_str, words=words, score=score, title_trans=title_trans, summary_trans=summary_trans, star=star)
+            article_str, words=words, score=score, title_trans=title_trans, summary_trans=summary_trans, star=star)
 
         send2app(text, slack_id, line_token)
 

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -82,7 +82,7 @@ def notify(results: list, template: str, slack_id: str, line_token: str) -> None
     # descending
     for result in sorted(results, reverse=True, key=lambda x: x.score):
         article = result.article
-        word = result.words
+        words = result.words
         score = result.score
 
         title_trans = get_translated_text('ja', 'en', article['title'])
@@ -91,7 +91,8 @@ def notify(results: list, template: str, slack_id: str, line_token: str) -> None
         # summary_trans = '\n'.join(summary_trans)
         result_str = {key: nice_str(article[key]) for key in article.keys()}
 
-        text = Template(template).substitute(result_str, title_trans=title_trans, summary_trans=summary_trans)
+        text = Template(template).substitute(
+            result_str, words=words, score=score, title_trans=title_trans, summary_trans=summary_trans, star=star)
 
         send2app(text, slack_id, line_token)
 
@@ -164,10 +165,10 @@ def main():
     if template is None:
         template = '\n score: `${score}`'\
                    '\n hit keywords: `${words}`'\
-                   '\n url: ${url}'\
-                   '\n title:    ${title}'\
+                   '\n url: ${arxiv_url}'\
+                   '\n title:    ${title_trans}'\
                    '\n abstract:'\
-                   '\n \t ${abstract_trans}'\
+                   '\n \t ${summary_trans}'\
                    '\n ${star}'
 
     day_before_yesterday = datetime.datetime.today() - datetime.timedelta(days=2)

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -1,3 +1,4 @@
+from re import template
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -76,7 +77,7 @@ def send2app(text: str, slack_id: str, line_token: str) -> None:
         requests.post(line_notify_api, headers=headers, data=data)
 
 
-def notify(results: list, slack_id: str, line_token: str) -> None:
+def notify(results: list, template: str, slack_id: str, line_token: str) -> None:
     # 通知
     star = '*'*80
     today = datetime.date.today()
@@ -166,6 +167,15 @@ def main():
     subject = config['subject']
     keywords = config['keywords']
     score_threshold = float(config['score_threshold'])
+    template = config['template']
+    if template is None:
+        template = '\n score: `${score}`'\
+                   '\n hit keywords: `${words}`'\
+                   '\n url: ${url}'\
+                   '\n title:    ${title}'\
+                   '\n abstract:'\
+                   '\n \t ${abstract_trans}'\
+                   '\n ${star}'
 
     day_before_yesterday = datetime.datetime.today() - datetime.timedelta(days=2)
     day_before_yesterday_str = day_before_yesterday.strftime('%Y%m%d')
@@ -181,7 +191,7 @@ def main():
 
     slack_id = os.getenv("SLACK_ID") or args.slack_id
     line_token = os.getenv("LINE_TOKEN") or args.line_token
-    notify(results, slack_id, line_token)
+    notify(results, template, slack_id, line_token)
 
 
 if __name__ == "__main__":

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -76,7 +76,7 @@ def send2app(text: str, slack_id: str, line_token: str) -> None:
         requests.post(line_notify_api, headers=headers, data=data)
 
 
-def notify(results: list, slack_id: str, line_token: str) -> None:
+def notify(results: list, template: str, slack_id: str, line_token: str) -> None:
     # 通知
     star = '*'*80
     today = datetime.date.today()
@@ -166,6 +166,15 @@ def main():
     subject = config['subject']
     keywords = config['keywords']
     score_threshold = float(config['score_threshold'])
+    template = config['template']
+    if template is None:
+        template = '\n score: `${score}`'\
+                   '\n hit keywords: `${words}`'\
+                   '\n url: ${url}'\
+                   '\n title:    ${title}'\
+                   '\n abstract:'\
+                   '\n \t ${abstract_trans}'\
+                   '\n ${star}'
 
     day_before_yesterday = datetime.datetime.today() - datetime.timedelta(days=2)
     day_before_yesterday_str = day_before_yesterday.strftime('%Y%m%d')
@@ -181,7 +190,7 @@ def main():
 
     slack_id = os.getenv("SLACK_ID") or args.slack_id
     line_token = os.getenv("LINE_TOKEN") or args.line_token
-    notify(results, slack_id, line_token)
+    notify(results, template, slack_id, line_token)
 
 
 if __name__ == "__main__":

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -43,15 +43,17 @@ def calc_score(abst: str, keywords: dict) -> (float, list):
 
 def search_keyword(
         articles: list, keywords: dict, score_threshold: float
-        ) -> list:
+) -> list:
     results = []
 
     for article in articles:
         abstract = article['summary']
         score, hit_keywords = calc_score(abstract, keywords)
         if (score != 0) and (score >= score_threshold):
-            title_trans = get_translated_text('ja', 'en', article['title'].replace('\n', ' '))
-            summary_trans = get_translated_text('ja', 'en', article['summary'].replace('\n', ' '))
+            title_trans = get_translated_text(
+                'ja', 'en', article['title'].replace('\n', ' '))
+            summary_trans = get_translated_text(
+                'ja', 'en', article['summary'].replace('\n', ' '))
             # summary_trans = textwrap.wrap(summary_trans, 40)  # 40行で改行
             # summary_trans = '\n'.join(summary_trans)
             result = Result(
@@ -73,6 +75,7 @@ def send2app(text: str, slack_id: str, line_token: str) -> None:
         data = {'message': f'message: {text}'}
         requests.post(line_notify_api, headers=headers, data=data)
 
+
 def nice_str(obj) -> str:
     if isinstance(obj, list):
         if all(type(elem) is str for elem in obj):
@@ -80,6 +83,7 @@ def nice_str(obj) -> str:
     if type(obj) is str:
         return obj.replace('\n', ' ')
     return str(obj)
+
 
 def notify(results: list, template: str, slack_id: str, line_token: str) -> None:
     # 通知

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -1,21 +1,23 @@
-from webdriver_manager.chrome import ChromeDriverManager
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-import os
-import time
-import yaml
-import datetime
-import slackweb
 import argparse
+import datetime
+import os
 import textwrap
-from bs4 import BeautifulSoup
-import warnings
+import time
 import urllib.parse
+import warnings
 from dataclasses import dataclass
+from string import Template
+
 import arxiv
 import requests
+import slackweb
+import yaml
+from bs4 import BeautifulSoup
 from feedparser import FeedParserDict
-from string import Template
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from webdriver_manager.chrome import ChromeDriverManager
+
 # setting
 warnings.filterwarnings('ignore')
 

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -82,11 +82,11 @@ def notify(results: list, template: str, slack_id: str, line_token: str) -> None
     # descending
     for result in sorted(results, reverse=True, key=lambda x: x.score):
         article = result.article
-        words = result.words
+        words = nice_str(result.words)
         score = result.score
 
-        title_trans = get_translated_text('ja', 'en', article['title'])
-        summary_trans = get_translated_text('ja', 'en', article['summary'].replace('\n', ''))
+        title_trans = get_translated_text('ja', 'en', article['title'].replace('\n', ' '))
+        summary_trans = get_translated_text('ja', 'en', article['summary'].replace('\n', ' '))
         # summary_trans = textwrap.wrap(summary_trans, 40)  # 40行で改行
         # summary_trans = '\n'.join(summary_trans)
         result_str = {key: nice_str(article[key]) for key in article.keys()}

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -161,15 +161,14 @@ def main():
     subject = config['subject']
     keywords = config['keywords']
     score_threshold = float(config['score_threshold'])
-    template = config['template']
-    if template is None:
-        template = '\n score: `${score}`'\
-                   '\n hit keywords: `${words}`'\
-                   '\n url: ${arxiv_url}'\
-                   '\n title:    ${title_trans}'\
-                   '\n abstract:'\
-                   '\n \t ${summary_trans}'\
-                   '\n ${star}'
+    default_template = '\n score: `${score}`'\
+                       '\n hit keywords: `${words}`'\
+                       '\n url: ${arxiv_url}'\
+                       '\n title:    ${title_trans}'\
+                       '\n abstract:'\
+                       '\n \t ${summary_trans}'\
+                       '\n ${star}'
+    template = config.get('template', default_template)
 
     day_before_yesterday = datetime.datetime.today() - datetime.timedelta(days=2)
     day_before_yesterday_str = day_before_yesterday.strftime('%Y%m%d')


### PR DESCRIPTION
素晴らしい機能をありがとうございます！
よりよくできればと思い、変更を提案します。お時間のある時にみてください。

## 本PRの動機
### 1
#54, #66 で送信メッセージに付与する情報を変更したい/増やしたいとの要望がありました。
そこで `config.yaml` にフィールドを増やして付与する情報を制御する案が出ていました。
例: https://github.com/fkubota/Carrier-Owl/issues/54#issuecomment-776439292
しかし `config.yaml` にフィールドを増やすのは、以下の点で得策ではないと考えています。

- 他に制御したい情報が現れたときにその都度フィールドを増やさなければならない
- フィールドが増えると `config.yaml` のパースが大変になる
  - クラスのメンバ、もしくは関数の引数が増加する
  - フィールドを必須にするか任意にするか? 任意の場合デフォルト値は?

### 2
別の動機として、送信メッセージを装飾したいというニーズがあると思います。

## 方法
以上の要望を `string.Template` クラスの [`substitute`](https://docs.python.org/ja/3.7/library/string.html#string.Template.substitute) メンバを用いて実装したいと考えます。
これは、文字列を辞書を用いて置換する機能です。

```py
template = 'I am ${name}. I like ${fruit}.'
d = {'name': 'Alice'}
s.substitute(d, fruit='apple')
# → 'I am Alice. I like apple.'
```

## 変更点
### `template` フィールド
`config.yaml` に `template` というフィールドを追加しました。 **このフィールドは必須ではありません**。
以下の設定で以下の結果が得られます。

```yaml
# メッセージテンプレート
template: |
        *${title}*
        👤 *Authors*: ${authors}
        🔑 *Keywords*: ${words}
        ⚽ *Score*: ${score}
        🔗 *URL*: ${arxiv_url}
        📝 *Abstract*:
        　${summary_trans}
        ￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣￣
```
<img width="900" alt="スクリーンショット 2022-03-16 16 22 49" src="https://user-images.githubusercontent.com/48613285/158538824-54ed121c-4e61-4c62-b5b7-0f7c266859bf.png">

### `template` フィールドのデフォルト値
`template` を設定しない場合のデフォルト値とその結果を下に示します。

```py
# メッセージテンプレートのデフォルト値
default_template = '\n score: `${score}`'\
                   '\n hit keywords: `${words}`'\
                   '\n url: ${arxiv_url}'\
                   '\n title:    ${title_trans}'\
                   '\n abstract:'\
                   '\n \t ${summary_trans}'\
                   '\n ${star}'
```
<img width="895" alt="スクリーンショット 2022-03-16 16 22 17" src="https://user-images.githubusercontent.com/48613285/158538873-492fa8c1-1d3d-4249-a454-0c8933b17af6.png">

### `template` フィールドで使える変数
#### arXiv API 由来の変数
arXiv API 由来の変数は　arXiv API で用いられている名称そのものを用いています。
詳細は [Reference](https://arxiv.org/help/api/user-manual#_details_of_atom_results_returned) を確認してください。
よく使うものを以下に示します。

|変数|説明|
|-|-|
|`${arxiv_comment}`|著者のコメント(あれば)|
|`${arxiv_url}`|URL|
|`${authors}`|著者|
|`${published}`|公開日|
|`${summary}`|概要(アブストラクト)|
|`${title}`|論文のタイトル|
|`${updated}`|更新日|

#### arXiv API 由来でない変数
翻訳された概要などの arXiv API 由来でない変数は以下のように設定しました。

|変数|説明|
|-|-|
|`${words}`|ヒットしたキーワード|
|`${score}`|スコア(ヒットしたキーワードの重みの総和)|
|`${title_trans}`|翻訳されたタイトル|
|`${summary_trans}`|翻訳された概要|
|`${star}`|`'*'*80`|

- [ ] わかりにくい変数名がありましたら変更してください

## 実装の詳細
以下にコメントします。
