### PR TITLE
Selenium find2

### DIFF
--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -140,7 +140,7 @@ def get_translated_text(from_lang: str, to_lang: str, from_text: str, driver) ->
         if to_text:
             break
     if to_text is None:
-        return from_text
+        return urllib.parse.unquote(from_text)
     return to_text
 
 def get_text_from_driver(driver) -> str:

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -1,6 +1,7 @@
 from webdriver_manager.firefox import GeckoDriverManager
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options
+from selenium.common.exceptions import NoSuchElementException
 import os
 import time
 import yaml
@@ -138,10 +139,15 @@ def get_translated_text(from_lang: str, to_lang: str, from_text: str, driver) ->
 
         if to_text:
             break
+    if to_text is None:
+        return from_text
     return to_text
 
 def get_text_from_driver(driver) -> str:
-    elem = driver.find_element_by_class_name('lmt__translations_as_text__text_btn')
+    try:
+        elem = driver.find_element_by_class_name('lmt__translations_as_text__text_btn')
+    except NoSuchElementException as e:
+        return None
     text = elem.get_attribute('innerHTML')
     return text
 

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -133,12 +133,17 @@ def get_translated_text(from_lang: str, to_lang: str, from_text: str, driver) ->
         # 指定時間待つ
         time.sleep(sleep_time)
         html = driver.page_source
-        to_text = get_text_from_page_source(html)
+        # to_text = get_text_from_page_source(html)
+        to_text = get_text_from_driver(driver)
 
         if to_text:
             break
     return to_text
 
+def get_text_from_driver(driver) -> str:
+    elem = driver.find_element_by_class_name('lmt__translations_as_text__text_btn')
+    text = elem.get_attribute('innerHTML')
+    return text
 
 def get_text_from_page_source(html: str) -> str:
     soup = BeautifulSoup(html, features='lxml')


### PR DESCRIPTION
たまにlxmlでエレメントが見つけられないことがあるのでseleniumのfind_element_by_class_nameを使うようにしてみました。
あと、翻訳に失敗した場合に原文を返すようにしてみました。

今日(2022/7/20)の分についてはこの変更で手元では動作できています。
