### PR TITLE
update wheel version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["hppRC <hpp.ricecake@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-wheel = "^0.37.1"
+wheel = "^0.38.1"
 slackweb = "^1.0.5"
 lxml = "^4.6.3"
 pyyaml = "^5.3.1"


### PR DESCRIPTION
どうもwheel 0.37.1が配布されなくなったようで、0.38.1に上げて手元では動いています。
